### PR TITLE
Gave filament sensor switches a nicer and unique name

### DIFF
--- a/Modix/e0filamentsensor.cfg
+++ b/Modix/e0filamentsensor.cfg
@@ -1,7 +1,7 @@
-[filament_switch_sensor my_sensor]
+[filament_switch_sensor filament_e0]
 pause_on_runout: True
 #runout_gcode:
 #insert_gcode:
 event_delay: 1.0
 pause_delay: 0.5
-switch_pin:PD10
+switch_pin: PD10

--- a/Modix/e1filamentsensor.cfg
+++ b/Modix/e1filamentsensor.cfg
@@ -1,7 +1,7 @@
-[filament_switch_sensor my_sensor]
+[filament_switch_sensor filament_e1]
 pause_on_runout: True
 #runout_gcode:
 #insert_gcode:
 event_delay: 1.0
 pause_delay: 0.5
-switch_pin:PC16
+switch_pin: PC16

--- a/filamentrunout.cfg
+++ b/filamentrunout.cfg
@@ -1,7 +1,7 @@
-[filament_switch_sensor my_sensor]
+[filament_switch_sensor filament_e0]
 pause_on_runout: True
 #runout_gcode:
 #insert_gcode:
 event_delay: 1.0
 pause_delay: 0.5
-switch_pin:PD10
+switch_pin: PD10


### PR DESCRIPTION
Not sure if you want pull requests, but anyway here it goes :)

I thought it was weird that the filament sensor was called "my_sensor", so I fixed it. Also noticed, that the two different sensors for Modix had the same name, so I fixed them as well.